### PR TITLE
sys.exit if config/gui.json not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -333,7 +333,7 @@ class App(tkinter.Tk):
 
         except FileNotFoundError:
             print("APP: './Config/gui.json' not found.")
-            return
+            sys.exit(1)
 
         self.font = (self.gui_config["font"], self.gui_config["font_size"])
 


### PR DESCRIPTION
If Config/gui.json cannot be found GUI just displays a grey box and halts forever.
So sys.exit looks more appropriate for me ;-)